### PR TITLE
Update fluentd version

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,27 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  
+
+jobs:
+
+  build:
+
+    runs-on: windows-2019
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USER }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Build the Docker image # push The image to the docker hub
+      run: docker build . --file ./fluentd/Dockerfile --tag ${{ secrets.DOCKER_USER }}/fluentdwindows:${{github.run_number}}
+    - name: Docker Push
+      run: docker push ${{ secrets.DOCKER_USER }}/fluentdwindows:${{github.run_number}}
+

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ kubectl get pods -n amazon-cloudwatch
 
 ## 3) Deploy an IIS pod created with [Logmonitor](https://github.com/microsoft/windows-container-tools/tree/master/LogMonitor)
 
+**LogMonitor is only required here because we are using IIS which run as a windows service and don't output in the stdout**
 
 ```console
 kubectl apply -f https://raw.githubusercontent.com/bgsilvait/k8s-fluentd-windows/master/k8s/deployment-iisbgs.yaml

--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -1,45 +1,38 @@
+
 FROM mcr.microsoft.com/windows/servercore:ltsc2019 as base
 
-#Set powershell as default shell
-SHELL ["powershell", "-NoLogo", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+# Do not split this into multiple RUN!
+# Docker creates a layer for every RUN-Statement
+RUN powershell -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))"
 
-#Install chocolatey package manager
-RUN Set-ExecutionPolicy Bypass -Scope Process -Force; \
-    iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+# Fluentd depends on cool.io whose fat gem is only available for Ruby < 2.5, so need to specify --platform ruby when install Ruby > 2.5 and install msys2 to get dev tools
+# NOTE: For avoiding stalling with docker build on windows, we must use latest version of msys2.
+RUN choco install -y ruby --version 2.7.2.1 --params "'/InstallDir:C:\ruby27'" \
+&& choco install -y msys2 --version 20211130.0.0 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby27\msys64'"
+RUN refreshenv \
+&& ridk install 3 \
+&& echo gem: --no-document >> C:\ProgramData\gemrc \
+&& gem install cool.io -v 1.5.4 --platform ruby \
+&& gem install oj -v 3.3.10 \
+&& gem install json -v 2.2.0 \
+&& gem install fluentd -v 1.14.6 \
+&& gem install win32-service -v 2.1.6 \
+&& gem install win32-ipc -v 0.7.0 \
+&& gem install win32-event -v 0.6.3 \
+&& gem install windows-pr -v 1.2.6 \
+&& gem install aws-sdk-cloudwatchlogs \
+&& gem install fluent-plugin-concat \
+&& gem install fluent-plugin-rewrite-tag-filter \
+&& gem install fluent-plugin-multi-format-parser \
+&& gem install fluent-plugin-cloudwatch-logs \
+&& gem install fluent-plugin-kubernetes_metadata_filter \
+&& gem sources --clear-all
 
-#Install ruby and msys2 with chocolatey
-RUN choco install -y ruby --version 2.6.5.1 --params "'/InstallDir:C:\ruby26'"; \
-    choco install -y msys2 --params "'/NoPath /NoUpdate /InstallDir:C:\ruby26\msys64'"
-
-#Install Ruby gems from fluentd Dockerfile + aws-sdk-cloudwatchlogs + Fluent plugins to parse and rewrite the logs
-RUN refreshenv; \
-ridk install 2 3; \
-'gem: --no-document' | Out-File -Encoding UTF8 -NoNewline -Force -FilePath 'C:\ProgramData\gemrc'; \
-gem install bundler; \
-bundle config build.certstore_c --with-cflags="-Wno-attributes"; \
-bundle config build.yajl-ruby --with-cflags="-Wno-attributes"; \
-bundle config build.oj --with-cflags="-Wno-attributes"; \
-gem install cool.io -v 1.5.4 --platform ruby; \
-gem install oj -v 3.3.10; \
-gem install json -v 2.2.0; \
-gem install fluentd -v 1.11.5; \
-gem install win32-service -v 1.0.1; \
-gem install win32-ipc -v 0.7.0; \
-gem install win32-event -v 0.6.3; \
-gem install windows-pr -v 1.2.6; \
-gem install aws-sdk-cloudwatchlogs; \
-gem install fluent-plugin-concat; \
-gem install fluent-plugin-rewrite-tag-filter; \
-gem install fluent-plugin-multi-format-parser; \
-gem install fluent-plugin-cloudwatch-logs; \
-gem sources --clear-all; \
-Remove-Item -Force C:\ruby26\lib\ruby\gems\2.6.0\cache\*.gem; \
-Remove-Item -Recurse -Force C:\ProgramData\chocolatey
 
 FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
-COPY --from=base /ruby26 /ruby26
+COPY --from=base /ruby27 /ruby27
 
-RUN setx /M PATH ""C:\ruby26\bin;%PATH%"
+RUN setx /M PATH "C:\ruby27\bin;%PATH%"
 
 CMD ["powershell", "-command", "fluentd"]

--- a/k8s/configmap-fluentd-windowsbgs.yaml
+++ b/k8s/configmap-fluentd-windowsbgs.yaml
@@ -10,45 +10,54 @@ data:
   CLUSTER_NAME: eks-windows
   fluent.conf: |
     <match fluent.**>
-      @type null
+      @type stdout
     </match>
 
     @include containers.conf
   containers.conf: |
-    <source>
-      @type tail
-      @id in_tail_container_logs
-      path /var/log/containers/*.log
-      exclude_path ["/var/log/containers/fluentd*"]
-      pos_file /var/log/fluentd-containers.log.pos
-      tag k8s.*
-      read_from_head true
-      <parse>
-        @type "json"
-        time_format %Y-%m-%dT%H:%M:%S.%NZ
-      </parse>
-    </source>
-    
-    <filter **>
-      @type record_transformer
-      @id filter_containers_stream_transformer
-      <record>
-        stream_name ${tag_parts[4]}
-      </record>
-    </filter>
-    
-      <match k8s.**>
-        @type cloudwatch_logs
-        @id out_cloudwatch_logs_containers
-        region "#{ENV.fetch('AWS_REGION')}"
-        log_group_name "/EKS/#{ENV.fetch('CLUSTER_NAME')}/Windows"
-        log_stream_name_key stream_name
-        remove_log_stream_name_key true
-        auto_create_stream true
-        <buffer>
-          flush_interval 5
-          chunk_limit_size 2m
-          queued_chunks_limit_size 32
-          retry_forever true
-        </buffer>
-      </match>
+        <source>
+          @type tail
+          @id in_tail_container_logs
+          @label @mainstream
+          path /var/log/containers/*.log
+          exclude_path ["/var/log/containers/fluentd*"]
+          pos_file /var/log/fluentd-containers.log.pos
+          tag k8s.*
+          read_from_head true
+          <parse>
+            @type "json"
+            time_format %Y-%m-%dT%H:%M:%S.%NZ
+          </parse>
+        </source>
+       
+
+        <label @mainstream>
+          <filter **>
+            @type kubernetes_metadata
+            @id filter_kube_metadata
+          </filter>
+
+          <filter **>
+            @type record_transformer
+            @id filter_containers_stream_transformer
+            <record>
+              stream_name ${tag_parts[4]}
+            </record>
+          </filter>
+
+          <match k8s.**>
+            @type cloudwatch_logs
+            @id out_cloudwatch_logs_containers
+            region "#{ENV.fetch('AWS_REGION')}"
+            log_group_name "/EKS/#{ENV.fetch('CLUSTER_NAME')}/Windows"
+            log_stream_name_key stream_name
+            remove_log_stream_name_key true
+            auto_create_stream true
+            <buffer>
+              flush_interval 5
+              chunk_limit_size 2m
+              queued_chunks_limit_size 32
+              retry_forever true
+            </buffer>
+          </match>
+        </label>


### PR DESCRIPTION
This PR contains:
 - a github workflow to publish the docker image
 - an upgrade of fluentd to latest version (the dockerfile provided was not working)
 - the kubernetes metadata plugin

closes #5 and closes #4  